### PR TITLE
Update Tooltip.tsx to fix react-dom-server leaking into client bundle

### DIFF
--- a/app/components/Tooltip.tsx
+++ b/app/components/Tooltip.tsx
@@ -1,6 +1,7 @@
-import type { ReactElement, ReactNode } from "react";
-// import ReactDOMServer from "react-dom/server";
+import { type ReactElement, type ReactNode, lazy } from "react";
 import { type PlacesType, Tooltip as TT } from "react-tooltip";
+import { lazily } from "react-lazily";
+const ReactDOMServer = lazily(() => import("react-dom/server"));
 
 type TooltipProps = {
    id: string;
@@ -26,7 +27,9 @@ export default function Tooltip({
          <div
             className={className}
             data-tooltip-id={id}
-            data-tooltip-html={html}
+            data-tooltip-html={
+               html ? ReactDOMServer.renderToStaticMarkup(html) : null
+            }
             data-tooltip-content={content}
             data-tooltip-place={side}
          >

--- a/app/components/Tooltip.tsx
+++ b/app/components/Tooltip.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement, ReactNode } from "react";
-import ReactDOMServer from "react-dom/server";
+// import ReactDOMServer from "react-dom/server";
 import { type PlacesType, Tooltip as TT } from "react-tooltip";
 
 type TooltipProps = {
@@ -26,7 +26,7 @@ export default function Tooltip({
          <div
             className={className}
             data-tooltip-id={id}
-            data-tooltip-html={ReactDOMServer.renderToStaticMarkup(html)}
+            data-tooltip-html={html}
             data-tooltip-content={content}
             data-tooltip-place={side}
          >


### PR DESCRIPTION
`react-dom-server` is leaking into the client bundle because it's used in eactly one place in Tooltip.tsx:

![image](https://github.com/manawiki/core/assets/84349818/ec9d201c-3173-4946-afbc-eb0d3cd56488)


Removing it cut about 70kb off the bundle:

![image](https://github.com/manawiki/core/assets/84349818/c9ce5537-47c5-42a1-b200-38f38ae6fe58)


@pogseal Making this a PR first, since I don't know whether this would break any tooltips in use atm.