### PR TITLE
Seed homeContents data upon site creation

### DIFF
--- a/app/db/collections/Sites.ts
+++ b/app/db/collections/Sites.ts
@@ -1,6 +1,50 @@
-import type { CollectionConfig } from "payload/types";
+import type { CollectionAfterChangeHook, CollectionConfig } from "payload/types";
 
 import { isStaff, isStaffFieldLevel, isLoggedIn } from "../../access/user";
+const afterCreateSite: CollectionAfterChangeHook = async ({
+   doc,
+   req: { payload },
+   operation, // name of the operation i.e. 'create', 'update'
+}) => {
+   try {
+      // On site creation, create a default homeContents entry
+      if (operation === "create") {
+         const siteId = doc.slug;
+         await payload.create({
+            collection: "homeContents",
+            data: {
+               site: siteId,
+               _status: "published",
+               content: [
+                  {
+                     id: "viwnxpInwb-HSLnwixmaU",
+                     type: "h2",
+                     children: [
+                        {
+                           text: "Welcome to Mana",
+                        }
+                     ]
+                  },
+                  {
+                     id: "jsowPnsUbN-UmsYfOpFtY",
+                     type: "paragraph",
+                     children: [
+                        {
+                           text: "This page was automatically generated during site creation, and it looks like it hasn't been replaced yet."
+                        }
+                     ]
+                  }
+               ]
+            },
+         });
+      }
+   } catch (err: unknown) {
+      console.log("ERROR");
+      payload.logger.error(`${err}`);
+   }
+
+   return doc;
+};
 
 export const sitesSlug = "sites";
 export const Sites: CollectionConfig = {
@@ -173,4 +217,7 @@ export const Sites: CollectionConfig = {
          type: "text",
       },
    ],
+   hooks: {
+      afterChange: [afterCreateSite],
+   },
 };


### PR DESCRIPTION
Introduced new `afterCreateSite` hook using `CollectionAfterChange` in `collections/Sites.ts` to seed `homeContents` data.

![image](https://github.com/manawiki/core/assets/5971630/c861ab7b-a0dd-42c1-9b5c-0b36a25e57cd)
