### PR TITLE
Editor version modal updates

### DIFF
--- a/app/db/collections/HomeContents.ts
+++ b/app/db/collections/HomeContents.ts
@@ -1,12 +1,20 @@
+import payload from "payload";
 import type {CollectionBeforeChangeHook , CollectionConfig} from "payload/types";
+
 import type { User } from "payload/generated-types";
 
 import { canMutateAsSiteAdmin, canRead } from "../../access/site";
 
 // Automatically replaces the lastEditedBy field before a change is submitted in order to allow us to determine which user made a specific document version
 const replaceLastEditedBy: CollectionBeforeChangeHook = async ({ data, req, operation, originalDoc }) => {
-   data.user = req.user.id;
-   return data;
+   try {
+      if(operation == "update") {
+          data.user = req.user.id;
+      }
+      return data;
+   } catch (err: unknown) {
+      payload.logger.error(`${err}`);
+   }
 };
 
 export const HomeContents: CollectionConfig = {
@@ -27,9 +35,8 @@ export const HomeContents: CollectionConfig = {
          name: "user",
          type: "relationship",
          relationTo: "users",
-         defaultValue: ({ user }: { user: User }) => user.id,
          maxDepth: 3,
-         required: true,
+         required: false,
       },
       {
          name: "site",

--- a/app/db/collections/HomeContents.ts
+++ b/app/db/collections/HomeContents.ts
@@ -1,21 +1,8 @@
 import payload from "payload";
-import type {CollectionBeforeChangeHook , CollectionConfig} from "payload/types";
-
-import type { User } from "payload/generated-types";
+import type {CollectionConfig} from "payload/types";
 
 import { canMutateAsSiteAdmin, canRead } from "../../access/site";
-
-// Automatically replaces the lastEditedBy field before a change is submitted in order to allow us to determine which user made a specific document version
-const replaceLastEditedBy: CollectionBeforeChangeHook = async ({ data, req, operation, originalDoc }) => {
-   try {
-      if(operation == "update") {
-          data.user = req.user.id;
-      }
-      return data;
-   } catch (err: unknown) {
-      payload.logger.error(`${err}`);
-   }
-};
+import {replaceVersionAuthor} from "../hooks/replaceVersionAuthor";
 
 export const HomeContents: CollectionConfig = {
    slug: "homeContents",
@@ -32,11 +19,14 @@ export const HomeContents: CollectionConfig = {
          type: "json",
       },
       {
-         name: "user",
+         name: "versionAuthor",
          type: "relationship",
          relationTo: "users",
          maxDepth: 3,
          required: false,
+         admin: {
+            hidden: true,
+         }
       },
       {
          name: "site",
@@ -48,7 +38,7 @@ export const HomeContents: CollectionConfig = {
       },
    ],
    hooks: {
-      beforeChange: [replaceLastEditedBy],
+      beforeChange: [replaceVersionAuthor],
    },
    versions: {
       drafts: {

--- a/app/db/collections/Posts.ts
+++ b/app/db/collections/Posts.ts
@@ -4,6 +4,7 @@ import type { User } from "payload/generated-types";
 
 import { canMutateAsSiteAdmin, canRead } from "../../access/site";
 import { isStaffFieldLevel } from "../../access/user";
+import {replaceVersionAuthor} from "../hooks/replaceVersionAuthor";
 
 export const Posts: CollectionConfig = {
    slug: "posts",
@@ -71,7 +72,20 @@ export const Posts: CollectionConfig = {
          type: "upload",
          relationTo: "images",
       },
+      {
+         name: "versionAuthor",
+         type: "relationship",
+         relationTo: "users",
+         maxDepth: 3,
+         required: false,
+         admin: {
+            hidden: true,
+         }
+      },
    ],
+   hooks: {
+      beforeChange: [replaceVersionAuthor]
+   },
    versions: {
       drafts: {
          autosave: true,

--- a/app/db/hooks/replaceVersionAuthor.ts
+++ b/app/db/hooks/replaceVersionAuthor.ts
@@ -1,0 +1,20 @@
+import payload from "payload";
+import type {CollectionBeforeChangeHook} from "payload/types";
+
+// Automatically replaces the versionAuthor field before a change is submitted
+// in order to allow us to determine which user made a specific document version
+export const replaceVersionAuthor: CollectionBeforeChangeHook = async ({
+   data,
+   req,
+   operation,
+   originalDoc
+}) => {
+   try {
+      if(operation == "update") {
+         data.versionAuthor = req.user.id;
+      }
+      return data;
+   } catch (err: unknown) {
+      payload.logger.error(`${err}`);
+   }
+};

--- a/app/routes/_editor+/core/components/EditorVersionModal.tsx
+++ b/app/routes/_editor+/core/components/EditorVersionModal.tsx
@@ -68,9 +68,9 @@ export function EditorVersionModal({
                                  className="bg-3 shadow-1 flex h-5 w-5 items-center justify-center
                                           overflow-hidden rounded-full border border-zinc-200 shadow-sm dark:border-zinc-600"
                               >
-                                 {selectedVersion?.version?.user?.avatar?.url ? (
+                                 {selectedVersion?.version?.versionAuthor?.avatar?.url ? (
                                     <Image
-                                       url={selectedVersion?.version?.user?.avatar?.url}
+                                       url={selectedVersion?.version?.versionAuthor?.avatar?.url}
                                        options="aspect_ratio=1:1&height=80&width=80"
                                        alt="User Avatar"
                                     />
@@ -82,7 +82,7 @@ export function EditorVersionModal({
                                     />
                                  )}
                               </div>
-                              <div className="pl-2">{selectedVersion?.version?.user?.username ?? ("Unknown contributor")}</div>
+                              <div className="pl-2">{selectedVersion?.version?.versionAuthor?.username ?? ("Unknown contributor")}</div>
                            </div>
                         </div>
                      </div>

--- a/app/routes/_editor+/core/components/EditorVersionModal.tsx
+++ b/app/routes/_editor+/core/components/EditorVersionModal.tsx
@@ -7,7 +7,7 @@ import clsx from "clsx";
 import dt from "date-and-time";
 
 import type { Config } from "payload/generated-types";
-import { Modal } from "~/components";
+import { Image, Modal } from "~/components";
 import { Icon } from "~/components/Icon";
 import { isAdding } from "~/utils";
 
@@ -29,7 +29,7 @@ export function EditorVersionModal({
    const versions =
       collectionSlug == "contentEmbeds"
          ? data.entry.embeddedContent.find((item: any) => item?.id === pageId)
-              ?.versions ?? []
+         ?.versions ?? []
          : data?.versions ?? [];
 
    const fetcher = useFetcher();
@@ -52,14 +52,39 @@ export function EditorVersionModal({
                <Tab.Group>
                   <Tab.Panels className="bg-3 max-h-[90vh] w-[775px] overflow-auto px-4 pb-4 no-scrollbar">
                      <div
-                        className="bg-2-sub text-1 border-color-sub fixed left-0 top-0 z-20 
+                        className="bg-2-sub text-1 border-color-sub fixed left-0 top-0 z-20
                         mb-3 flex h-12 w-[775px] items-center border-b px-4 text-sm font-bold"
                      >
-                        {selectedVersion?.updatedAt &&
-                           dt.format(
-                              new Date(selectedVersion?.updatedAt as any),
-                              "MMMM D, hh:mm A",
-                           )}
+                        <div className="flex gap-x-2">
+                           <div>
+                              {selectedVersion?.updatedAt &&
+                                 dt.format(
+                                    new Date(selectedVersion?.updatedAt as any),
+                                    "MMMM D, hh:mm A",
+                                 )}
+                           </div>
+                           <div className="border-l border-color-sub flex pl-2">
+                              <div
+                                 className="bg-3 shadow-1 flex h-5 w-5 items-center justify-center
+                                          overflow-hidden rounded-full border border-zinc-200 shadow-sm dark:border-zinc-600"
+                              >
+                                 {selectedVersion?.version?.user?.avatar?.url ? (
+                                    <Image
+                                       url={selectedVersion?.version?.user?.avatar?.url}
+                                       options="aspect_ratio=1:1&height=80&width=80"
+                                       alt="User Avatar"
+                                    />
+                                 ) : (
+                                    <Icon
+                                       name="dog"
+                                       className="text-1 m-0.5"
+                                       size={20}
+                                    />
+                                 )}
+                              </div>
+                              <div className="pl-2">{selectedVersion?.version?.user?.username ?? ("Unknown contributor")}</div>
+                           </div>
+                        </div>
                      </div>
                      {versions?.map(
                         (version: any) =>
@@ -153,7 +178,7 @@ export function EditorVersionModal({
                               )}
                            </button>
                            <button
-                              className="h-9 rounded-md bg-zinc-200 text-sm 
+                              className="h-9 rounded-md bg-zinc-200 text-sm
                            font-bold focus:bg-zinc-100 dark:bg-zinc-700 dark:focus:bg-zinc-600"
                               onClick={() => {
                                  setVersionModal(false);

--- a/app/routes/_site+/$siteId+/_index.tsx
+++ b/app/routes/_site+/$siteId+/_index.tsx
@@ -115,11 +115,11 @@ export default function SiteIndexMain() {
 }
 
 async function fetchHomeUpdates({
-                                   payload,
-                                   siteId,
-                                   user,
-                                   request,
-                                }: {
+   payload,
+   siteId,
+   user,
+   request,
+}: {
    payload: Payload;
    siteId: Site["slug"];
    user?: User;
@@ -172,12 +172,12 @@ async function fetchHomeUpdates({
 }
 
 async function fetchHomeContent({
-                                   payload,
-                                   siteId,
-                                   user,
-                                   request,
-                                   page = 1,
-                                }: {
+   payload,
+   siteId,
+   user,
+   request,
+   page = 1,
+}: {
    payload: Payload;
    siteId: Site["slug"];
    user?: User;
@@ -238,8 +238,6 @@ async function fetchHomeContent({
                   },
                   doc.version,
                );
-
-               console.log(JSON.stringify(version, null, 2));
 
                //Combine final result
                const result = {

--- a/app/routes/_site+/$siteId+/_index.tsx
+++ b/app/routes/_site+/$siteId+/_index.tsx
@@ -30,10 +30,10 @@ import { ManaEditor } from "~/routes/_editor+/editor";
 import { fetchWithCache } from "~/utils/cache.server";
 
 export async function loader({
-   context: { payload, user },
-   params,
-   request,
-}: LoaderFunctionArgs) {
+                                context: { payload, user },
+                                params,
+                                request,
+                             }: LoaderFunctionArgs) {
    const siteId = params?.siteId ?? customConfig?.siteId;
    const { page } = zx.parseQuery(request, {
       page: z.coerce.number().optional(),
@@ -115,11 +115,11 @@ export default function SiteIndexMain() {
 }
 
 async function fetchHomeUpdates({
-   payload,
-   siteId,
-   user,
-   request,
-}: {
+                                   payload,
+                                   siteId,
+                                   user,
+                                   request,
+                                }: {
    payload: Payload;
    siteId: Site["slug"];
    user?: User;
@@ -172,12 +172,12 @@ async function fetchHomeUpdates({
 }
 
 async function fetchHomeContent({
-   payload,
-   siteId,
-   user,
-   request,
-   page = 1,
-}: {
+                                   payload,
+                                   siteId,
+                                   user,
+                                   request,
+                                   page = 1,
+                                }: {
    payload: Payload;
    siteId: Site["slug"];
    user?: User;
@@ -233,10 +233,13 @@ async function fetchHomeContent({
                   {
                      id: false,
                      content: true,
+                     user: true,
                      _status: true,
                   },
                   doc.version,
                );
+
+               console.log(JSON.stringify(version, null, 2));
 
                //Combine final result
                const result = {
@@ -291,9 +294,9 @@ async function fetchHomeContent({
 }
 
 export async function action({
-   context: { payload, user },
-   request,
-}: ActionFunctionArgs) {
+                                context: { payload, user },
+                                request,
+                             }: ActionFunctionArgs) {
    const { intent } = await zx.parseForm(request, {
       intent: z.enum(["publish"]),
    });

--- a/app/routes/_site+/$siteId+/_index.tsx
+++ b/app/routes/_site+/$siteId+/_index.tsx
@@ -233,7 +233,7 @@ async function fetchHomeContent({
                   {
                      id: false,
                      content: true,
-                     user: true,
+                     versionAuthor: true,
                      _status: true,
                   },
                   doc.version,

--- a/app/routes/_site+/$siteId.p+/$p.tsx
+++ b/app/routes/_site+/$siteId.p+/$p.tsx
@@ -628,6 +628,7 @@ async function fetchPost({
             const version = select(
                {
                   id: false,
+                  versionAuthor: true,
                   content: true,
                   _status: true,
                },


### PR DESCRIPTION
This PR adds a new hidden field `versionAuthor` to both `HomeContents` and `Posts` to allow for tracking which specific user created a document version and introduces a new `beforeChange` hook.

Using this information, we can display the versionAuthor's information within `EditorVersionModal`.

If a particular document does not have a `versionAuthor` assigned (which should, currently, only be the case following site creation), then "Unknown contributor" is used instead.

![image](https://github.com/manawiki/core/assets/5971630/e0272bda-a7b4-4114-94f1-59782c3d56c1)
