### PR TITLE
Small fix to add placeholder subSection to resolve issue upon collection creation

### DIFF
--- a/app/routes/_site+/$siteId.collections+/_collections.tsx
+++ b/app/routes/_site+/$siteId.collections+/_collections.tsx
@@ -352,7 +352,7 @@ export const action: ActionFunction = async ({
                   customEntryTemplate,
                   customDatabase,
                   //@ts-ignore
-                  sections: [{ id: "main", name: "Main", showTitle: false }],
+                  sections: [{ id: "main", name: "Main", showTitle: false, subSections: [{id: "mainsubsection", name: "Main Subsection", type: "editor", showTitle: false}] }],
                },
                user,
                overrideAccess: false,


### PR DESCRIPTION
Fixes an issue where the server console outputs the following error when a user attempts to create a new Mana collection from the app: `ERROR (payload): ValidationError: The following field is invalid: sections.0.subSections.0.id`

See the following Discord messages for more information: https://discord.com/channels/1065543999202529300/1113669014011510974/1185045653110399137
https://discord.com/channels/1065543999202529300/1113669014011510974/1186112996498485357 (read down)