### PR TITLE
Fix type errors & avoid large unions type

### DIFF
--- a/app/components/Avatar.tsx
+++ b/app/components/Avatar.tsx
@@ -11,14 +11,14 @@ import { Image } from "~/components/Image";
 import { TouchTarget } from "./Button";
 import { Link } from "./Link";
 
-type AvatarProps = {
+interface AvatarProps extends React.ComponentPropsWithoutRef<"span"> {
    src?: string | null;
    square?: boolean;
    initials?: string;
    alt?: string;
    className?: string;
    options?: string;
-};
+}
 
 export function Avatar({
    src = null,
@@ -28,7 +28,7 @@ export function Avatar({
    className,
    options,
    ...props
-}: AvatarProps & React.ComponentPropsWithoutRef<"span">) {
+}: AvatarProps) {
    return (
       <span
          data-slot="avatar"

--- a/app/components/Badge.tsx
+++ b/app/components/Badge.tsx
@@ -37,13 +37,11 @@ let colors = {
    zinc: "bg-zinc-600/10 text-zinc-700 group-data-[hover]:bg-zinc-600/20 dark:bg-white/5 dark:text-zinc-400 dark:group-data-[hover]:bg-white/10",
 };
 
-type BadgeProps = { color?: keyof typeof colors };
+interface BadgeProps extends React.ComponentPropsWithoutRef<"span"> {
+   color?: keyof typeof colors;
+}
 
-export function Badge({
-   color = "zinc",
-   className,
-   ...props
-}: BadgeProps & React.ComponentPropsWithoutRef<"span">) {
+export function Badge({ color = "zinc", className, ...props }: BadgeProps) {
    return (
       <span
          {...props}
@@ -56,16 +54,23 @@ export function Badge({
    );
 }
 
+interface BadgeButtonProps extends HeadlessButtonProps {
+   color?: keyof typeof colors;
+   children: React.ReactNode;
+}
+
+interface LinkButtonProps extends React.ComponentPropsWithoutRef<typeof Link> {
+   color?: keyof typeof colors;
+   children: React.ReactNode;
+}
+
 export const BadgeButton = React.forwardRef(function BadgeButton(
    {
       color = "zinc",
       className,
       children,
       ...props
-   }: BadgeProps & { children: React.ReactNode } & (
-         | HeadlessButtonProps
-         | React.ComponentPropsWithoutRef<typeof Link>
-      ),
+   }: BadgeButtonProps | LinkButtonProps,
    ref: React.ForwardedRef<HTMLElement>,
 ) {
    let classes = clsx(

--- a/app/components/Dropdown.tsx
+++ b/app/components/Dropdown.tsx
@@ -35,13 +35,14 @@ export function DropdownButton<T extends React.ElementType = typeof Button>(
    return <HeadlessMenuButton as={Button} {...props} />;
 }
 
+interface DropdownMenuProps extends Omit<HeadlessMenuItemsProps, "anchor"> {
+   anchor?: NonNullable<HeadlessMenuItemsProps["anchor"]>["to"];
+}
+
 export function DropdownMenu({
    anchor = "bottom",
    ...props
-}: { anchor?: NonNullable<HeadlessMenuItemsProps["anchor"]>["to"] } & Omit<
-   HeadlessMenuItemsProps,
-   "anchor"
->) {
+}: DropdownMenuProps) {
    return (
       <HeadlessTransition
          as={Fragment}
@@ -85,9 +86,11 @@ export function DropdownMenu({
    );
 }
 
-export function DropdownItem(
-   props: { href?: string } & HeadlessMenuItemProps<"button">,
-) {
+interface DropdownItemProps extends HeadlessMenuItemProps<"button"> {
+   href?: string;
+}
+
+export function DropdownItem(props: DropdownItemProps) {
    return (
       <HeadlessMenuItem
          as={props.href ? Link : "button"}
@@ -210,11 +213,15 @@ export function DropdownDescription({
    );
 }
 
+interface DropdownShortcutProps extends HeadlessDescriptionProps<"kbd"> {
+   keys: string | string[];
+}
+
 export function DropdownShortcut({
    className,
    keys,
    ...props
-}: { keys: string | string[] } & HeadlessDescriptionProps<"kbd">) {
+}: DropdownShortcutProps) {
    return (
       <HeadlessDescription
          as="kbd"

--- a/app/components/Fieldset.tsx
+++ b/app/components/Fieldset.tsx
@@ -14,10 +14,11 @@ import {
 } from "@headlessui/react";
 import clsx from "clsx";
 
-export function Fieldset({
-   className,
-   ...props
-}: { disabled?: boolean } & HeadlessFieldsetProps) {
+interface FieldsetProps extends HeadlessFieldsetProps {
+   disabled?: boolean;
+}
+
+export function Fieldset({ className, ...props }: FieldsetProps) {
    return (
       <HeadlessFieldset
          {...props}
@@ -72,10 +73,11 @@ export function Field({ className, ...props }: HeadlessFieldProps) {
    );
 }
 
-export function Label({
-   className,
-   ...props
-}: { className?: string } & HeadlessLabelProps) {
+interface LabelProps extends HeadlessLabelProps {
+   className?: string;
+}
+
+export function Label({ className, ...props }: LabelProps) {
    return (
       <HeadlessLabel
          {...props}
@@ -88,11 +90,16 @@ export function Label({
    );
 }
 
+interface DescriptionProps extends HeadlessDescriptionProps {
+   className?: string;
+   disabled?: boolean;
+}
+
 export function Description({
    className,
    disabled,
    ...props
-}: { className?: string; disabled?: boolean } & HeadlessDescriptionProps) {
+}: DescriptionProps) {
    return (
       <HeadlessDescription
          {...props}
@@ -109,7 +116,7 @@ export function ErrorMessage({
    className,
    disabled,
    ...props
-}: { className?: string; disabled?: boolean } & HeadlessDescriptionProps) {
+}: DescriptionProps) {
    return (
       <HeadlessDescription
          {...props}

--- a/app/components/Icon.tsx
+++ b/app/components/Icon.tsx
@@ -11,17 +11,14 @@ import type { IconName } from "./icons";
  * you need to wrap the icon and text in a common parent and set the parent to
  * display "flex" (or "inline-flex") with "items-center" and a reasonable gap.
  */
-export function Icon({
-   name,
-   size,
-   title,
-   children,
-   ...props
-}: SVGProps<SVGSVGElement> & {
+
+interface IconProps extends SVGProps<SVGSVGElement> {
    name: IconName;
    size?: number;
    title?: string; // for accessibility
-}) {
+}
+
+export function Icon({ name, size, title, children, ...props }: IconProps) {
    if (children) {
       return (
          <span className="inline-flex items-center gap-1.5">

--- a/app/components/Image.tsx
+++ b/app/components/Image.tsx
@@ -1,3 +1,8 @@
+interface ImageProps extends React.ImgHTMLAttributes<HTMLImageElement> {
+   url?: string | null | undefined;
+   options?: string;
+}
+
 export function Image({
    url,
    options,
@@ -6,10 +11,7 @@ export function Image({
    width,
    height,
    ...props
-}: {
-   url?: string | null | undefined;
-   options?: string;
-} & React.ImgHTMLAttributes<HTMLImageElement>) {
+}: ImageProps) {
    const searchParams = new URLSearchParams(options);
 
    // If width is not provided, but it is in the options, insert it to hint the browser and reduce CLS

--- a/app/components/Link.tsx
+++ b/app/components/Link.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { DataInteractive as HeadlessDataInteractive } from "@headlessui/react";
 import { Link as RemixLink, type LinkProps } from "@remix-run/react";
 
-interface LinkPropsWithHref extends LinkProps {
+interface LinkPropsWithHref extends Omit<LinkProps, "to"> {
    href: LinkProps["to"];
 }
 

--- a/app/components/Link.tsx
+++ b/app/components/Link.tsx
@@ -3,13 +3,17 @@ import React from "react";
 import { DataInteractive as HeadlessDataInteractive } from "@headlessui/react";
 import { Link as RemixLink, type LinkProps } from "@remix-run/react";
 
+interface LinkPropsWithHref extends LinkProps {
+   href?: string;
+}
+
 export const Link = React.forwardRef(function Link(
-   props: { href: string | LinkProps["to"] } & Omit<LinkProps, "to">,
+   props: LinkPropsWithHref,
    ref: React.ForwardedRef<HTMLAnchorElement>,
 ) {
    return (
       <HeadlessDataInteractive>
-         <RemixLink {...props} to={props.href} ref={ref} />
+         <RemixLink {...props} to={props.href ?? props.to} ref={ref} />
       </HeadlessDataInteractive>
    );
 });

--- a/app/components/Link.tsx
+++ b/app/components/Link.tsx
@@ -4,7 +4,7 @@ import { DataInteractive as HeadlessDataInteractive } from "@headlessui/react";
 import { Link as RemixLink, type LinkProps } from "@remix-run/react";
 
 interface LinkPropsWithHref extends LinkProps {
-   href?: string;
+   href: LinkProps["to"];
 }
 
 export const Link = React.forwardRef(function Link(
@@ -13,7 +13,7 @@ export const Link = React.forwardRef(function Link(
 ) {
    return (
       <HeadlessDataInteractive>
-         <RemixLink {...props} to={props.href ?? props.to} ref={ref} />
+         <RemixLink {...props} to={props.href} ref={ref} />
       </HeadlessDataInteractive>
    );
 });

--- a/app/components/Modal.tsx
+++ b/app/components/Modal.tsx
@@ -5,12 +5,12 @@ import { Dialog, Transition } from "@headlessui/react";
 //A modal generic wrapper, pass in show and onClose to control the modal state, otherwise use it as a route modal
 export function Modal({
    show = true,
-   onClose,
+   onClose = () => {},
    children,
    unmount = true,
 }: {
    show?: boolean;
-   onClose?: () => void;
+   onClose: () => void;
    children?: React.ReactNode;
    unmount?: boolean;
 }) {

--- a/app/components/Switch.tsx
+++ b/app/components/Switch.tsx
@@ -29,11 +29,15 @@ export function SwitchGroup({
    );
 }
 
+interface SwitchFieldProps extends HeadlessFieldProps {
+   fullWidth?: boolean;
+}
+
 export function SwitchField({
    fullWidth = false,
    className,
    ...props
-}: { fullWidth?: boolean } & HeadlessFieldProps) {
+}: SwitchFieldProps) {
    return (
       <HeadlessField
          data-slot="field"
@@ -155,16 +159,18 @@ let colors = {
 
 type Color = keyof typeof colors;
 
+interface SwitchProps extends Omit<HeadlessSwitchProps, "children"> {
+   color?: Color;
+   className?: string;
+   children?: React.ReactNode;
+}
+
 export function Switch({
    color = "dark/zinc",
    className,
    children,
    ...props
-}: {
-   color?: Color;
-   className?: string;
-   children?: React.ReactNode;
-} & Omit<HeadlessSwitchProps, "children">) {
+}: SwitchProps) {
    return (
       <HeadlessSwitch
          data-slot="control"

--- a/app/components/Table.tsx
+++ b/app/components/Table.tsx
@@ -18,6 +18,14 @@ const TableContext = createContext<{
    framed: false,
 });
 
+interface TableProps extends React.ComponentPropsWithoutRef<"div"> {
+   bleed?: boolean;
+   dense?: boolean;
+   grid?: boolean;
+   striped?: boolean;
+   framed?: boolean;
+}
+
 export function Table({
    bleed = false,
    dense = false,
@@ -27,13 +35,7 @@ export function Table({
    className,
    children,
    ...props
-}: {
-   bleed?: boolean;
-   dense?: boolean;
-   grid?: boolean;
-   striped?: boolean;
-   framed?: boolean;
-} & React.ComponentPropsWithoutRef<"div">) {
+}: TableProps) {
    return (
       <TableContext.Provider
          value={
@@ -100,6 +102,12 @@ const TableRowContext = createContext<{
    grouped: false,
 });
 
+interface TableRowProps extends React.ComponentPropsWithoutRef<"tr"> {
+   href?: string;
+   target?: string;
+   title?: string;
+}
+
 export function TableRow({
    href,
    target,
@@ -107,11 +115,7 @@ export function TableRow({
    className,
    children,
    ...props
-}: {
-   href?: string;
-   target?: string;
-   title?: string;
-} & React.ComponentPropsWithoutRef<"tr">) {
+}: TableRowProps) {
    let { striped } = useContext(TableContext);
 
    return (
@@ -139,13 +143,11 @@ export function TableRow({
    );
 }
 
-export function TableHeader({
-   className,
-   center,
-   ...props
-}: {
+interface TableGroupProps extends React.ComponentPropsWithoutRef<"tr"> {
    center?: boolean;
-} & React.ComponentPropsWithoutRef<"th">) {
+}
+
+export function TableHeader({ className, center, ...props }: TableGroupProps) {
    let { bleed, grid, framed } = useContext(TableContext);
 
    return (
@@ -163,16 +165,18 @@ export function TableHeader({
    );
 }
 
+interface TableCellProps extends React.ComponentPropsWithoutRef<"td"> {
+   center?: boolean;
+   bold?: boolean;
+}
+
 export function TableCell({
    className,
    children,
    center,
    bold,
    ...props
-}: {
-   center?: boolean;
-   bold?: boolean;
-} & React.ComponentPropsWithoutRef<"td">) {
+}: TableCellProps) {
    let { bleed, dense, grid, striped, framed } = useContext(TableContext);
    let { href, target, title } = useContext(TableRowContext);
    let [cellRef, setCellRef] = useState<HTMLElement | null>(null);

--- a/app/components/Table.tsx
+++ b/app/components/Table.tsx
@@ -143,11 +143,11 @@ export function TableRow({
    );
 }
 
-interface TableGroupProps extends React.ComponentPropsWithoutRef<"tr"> {
+interface TableHeaderProps extends React.ComponentPropsWithoutRef<"th"> {
    center?: boolean;
 }
 
-export function TableHeader({ className, center, ...props }: TableGroupProps) {
+export function TableHeader({ className, center, ...props }: TableHeaderProps) {
    let { bleed, grid, framed } = useContext(TableContext);
 
    return (

--- a/app/components/Tooltip.tsx
+++ b/app/components/Tooltip.tsx
@@ -90,10 +90,11 @@ export const useTooltipState = () => {
    return context;
 };
 
-export function Tooltip({
-   children,
-   ...options
-}: { children: React.ReactNode } & TooltipOptions) {
+interface TooltipProps extends TooltipOptions {
+   children: React.ReactNode;
+}
+
+export function Tooltip({ children, ...options }: TooltipProps) {
    // This can accept any props as options, e.g. `placement`,
    // or other positioning options.
    const tooltip = useTooltip(options);
@@ -104,9 +105,13 @@ export function Tooltip({
    );
 }
 
+interface TooltipTriggerProps extends React.HTMLProps<HTMLElement> {
+   asChild?: boolean;
+}
+
 export const TooltipTrigger = React.forwardRef<
    HTMLElement,
-   React.HTMLProps<HTMLElement> & { asChild?: boolean }
+   TooltipTriggerProps
 >(function TooltipTrigger({ children, asChild = false, ...props }, propRef) {
    const state = useTooltipState();
 

--- a/app/routes/_editor+/blocks+/group/_group.tsx
+++ b/app/routes/_editor+/blocks+/group/_group.tsx
@@ -392,9 +392,11 @@ export function BlockGroup({
       return setGroupItems((items) => [...items, nodeId]);
    }
 
+   interface Editors extends BaseEditor, ReactEditor {}
+
    function handleUpdateItemsViewMode(
       event: any,
-      editor: BaseEditor & ReactEditor,
+      editor: Editors,
       element: GroupElement,
    ) {
       const path = ReactEditor.findPath(editor, element);

--- a/app/routes/_editor+/blocks+/tabs/_tabs.tsx
+++ b/app/routes/_editor+/blocks+/tabs/_tabs.tsx
@@ -113,6 +113,8 @@ export function BlockTabsItem({ element }: { element: TabsItemElement }) {
    );
 }
 
+interface Editors extends BaseEditor, ReactEditor {}
+
 function TabItem({
    element,
    editor,
@@ -121,7 +123,7 @@ function TabItem({
    readOnly,
 }: {
    element: TabsElement;
-   editor: BaseEditor & ReactEditor;
+   editor: Editors;
    fieldIndex: number;
    tab: string;
    readOnly: boolean;

--- a/app/routes/_editor+/core/dnd.tsx
+++ b/app/routes/_editor+/core/dnd.tsx
@@ -296,6 +296,12 @@ function DragOverlayContent({
    );
 }
 
+interface HoverElementProps extends RenderElementProps {
+   editor: Editor;
+   activeId: string | null;
+   isTwoColumn?: boolean;
+}
+
 function HoverElement({
    attributes,
    element,
@@ -303,11 +309,7 @@ function HoverElement({
    editor,
    activeId,
    isTwoColumn,
-}: RenderElementProps & {
-   editor: Editor;
-   activeId: string | null;
-   isTwoColumn?: boolean;
-}) {
+}: HoverElementProps) {
    const [isEditorTrayOpen, setEditorTray] = useState(false);
    const animateLayoutChanges: AnimateLayoutChanges = (args) =>
       defaultAnimateLayoutChanges({ ...args, wasDragging: true });

--- a/app/routes/_editor+/core/types.ts
+++ b/app/routes/_editor+/core/types.ts
@@ -4,9 +4,11 @@ import type { ReactEditor } from "slate-react";
 import type { Site, Collection } from "payload/generated-types";
 import type { Time } from "~/routes/_site+/_components/_datepicker/time-picker/types";
 
+interface Editors extends BaseEditor, ReactEditor {}
+
 declare module "slate" {
    interface CustomTypes {
-      Editor: BaseEditor & ReactEditor;
+      Editor: Editors;
       Element: CustomElement;
       Text: CustomText;
       Operation: BaseOperation & { isRemote?: boolean };
@@ -51,19 +53,19 @@ export type BlockElement = {
    children: CustomText[];
 };
 
-export type ParagraphElement = BlockElement & {
+export interface ParagraphElement extends BlockElement {
    type: BlockType.Paragraph;
-};
+}
 
-export type CodeBlockElement = BlockElement & {
+export interface CodeBlockElement extends BlockElement {
    type: BlockType.CodeBlock;
    value?: string;
-};
+}
 
-export type HTMLBlockElement = BlockElement & {
+export interface HTMLBlockElement extends BlockElement {
    type: BlockType.HTMLBlock;
    value?: string;
-};
+}
 
 export type InfoBoxElement = {
    id: string;
@@ -71,20 +73,20 @@ export type InfoBoxElement = {
    children: [InfoBoxItemElement];
 };
 
-export type InfoBoxItemElement = BlockElement & {
+export interface InfoBoxItemElement extends BlockElement {
    type: BlockType.InfoBoxItem;
    infoBoxLeftContent?: [Descendant];
    infoBoxRightContent?: [Descendant];
-};
+}
 
-export type InlineAdElement = BlockElement & {
+export interface InlineAdElement extends BlockElement {
    type: BlockType.InlineAd;
-};
+}
 
-export type HeadingElement = BlockElement & {
+export interface HeadingElement extends BlockElement {
    type: BlockType.H2 | BlockType.H3;
-};
-export type GroupItemElement = BlockElement & {
+}
+export interface GroupItemElement extends BlockElement {
    isCustomSite?: boolean;
    siteId: Site["slug"];
    type: BlockType.GroupItem;
@@ -95,7 +97,7 @@ export type GroupItemElement = BlockElement & {
    iconUrl?: string;
    path?: string;
    groupContent?: [Descendant];
-};
+}
 
 export type GroupElement = {
    id: string;
@@ -105,7 +107,7 @@ export type GroupElement = {
    children: [GroupItemElement];
 };
 
-export type EventItemElement = BlockElement & {
+export interface EventItemElement extends BlockElement {
    type: BlockType.EventItem;
    label?: string | null;
    startDate?: Date | null;
@@ -115,7 +117,7 @@ export type EventItemElement = BlockElement & {
    endTime?: Time;
    endTimestamp?: Date | null;
    eventContent?: [Descendant];
-};
+}
 
 export type EventsElement = {
    id: string;
@@ -123,10 +125,10 @@ export type EventsElement = {
    children: [EventItemElement];
 };
 
-export type TabsItemElement = BlockElement & {
+export interface TabsItemElement extends BlockElement {
    type: BlockType.TabsItem;
    tabContent?: [Descendant];
-};
+}
 
 export type TabsElement = {
    id: string;
@@ -135,9 +137,9 @@ export type TabsElement = {
    children: [TabsItemElement];
 };
 
-export type ListElement = BlockElement & {
+export interface ListElement extends BlockElement {
    type: BlockType.ListItem;
-};
+}
 
 export type NumberedListElement = {
    id: string;
@@ -163,31 +165,31 @@ export type BulletedListElement = {
    ];
 };
 
-export type ImageElement = BlockElement & {
+export interface ImageElement extends BlockElement {
    type: BlockType.Image;
    refId: string | null;
    url: string | null;
    children: [{ text: "" }];
-};
+}
 
-export type ToggleBlockElement = BlockElement & {
+export interface ToggleBlockElement extends BlockElement {
    type: BlockType.ToggleBlock;
    isOpen: boolean | undefined;
    children: [{ text: "" }];
    toggleBlockContent?: [Descendant];
-};
+}
 
-export type TwoColumnElement = BlockElement & {
+export interface TwoColumnElement extends BlockElement {
    type: BlockType.TwoColumn;
    columnOneContent?: [Descendant];
    columnTwoContent?: [Descendant];
-};
+}
 
-export type UpdatesElement = BlockElement & {
+export interface UpdatesElement extends BlockElement {
    type: BlockType.Updates;
-};
+}
 
-export type LinkElement = BlockElement & {
+export interface LinkElement extends BlockElement {
    type: BlockType.Link;
    url: string | undefined;
    icon: {
@@ -196,7 +198,7 @@ export type LinkElement = BlockElement & {
    name: string | undefined;
    view: "icon-inline" | undefined;
    children: [{ text: "" }];
-};
+}
 
 export type CustomElement =
    | ParagraphElement

--- a/app/routes/_editor+/core/utils.ts
+++ b/app/routes/_editor+/core/utils.ts
@@ -9,7 +9,7 @@ import { BlockType, type CustomElement, type Format } from "./types";
 
 //Helpers
 export function topLevelPath(path: Path): Path {
-   return [path[0]];
+   return [path[0]!];
 }
 
 export function initialValue(): CustomElement[] {
@@ -66,7 +66,7 @@ export function onKeyDown(event: any, editor: Editor) {
       if (isHotkey(hotkey, event as any) && editor.selection) {
          event.preventDefault();
          const mark = HOTKEYS[hotkey];
-         toggleMark(editor, mark);
+         if (mark) toggleMark(editor, mark);
       }
    }
 }

--- a/app/routes/_site+/_components/_datepicker/components/select/index.tsx
+++ b/app/routes/_site+/_components/_datepicker/components/select/index.tsx
@@ -15,7 +15,11 @@ export type OptionType<T> = {
    disabled: boolean;
 };
 
-type CustomSelectProps<T> = {
+interface CustomSelectProps<T>
+   extends Omit<
+      PropsWithChildren<HTMLProps<HTMLDivElement>>,
+      "onChange" | "value" | "disabled"
+   > {
    /**
     * The value of the select.
     */
@@ -38,10 +42,7 @@ type CustomSelectProps<T> = {
     * How to format the display value
     */
    formatValue?: (value: T) => string;
-} & Omit<
-   PropsWithChildren<HTMLProps<HTMLDivElement>>,
-   "onChange" | "value" | "disabled"
->;
+}
 
 /**
  * A custom select component.
@@ -71,14 +72,14 @@ function CustomSelect<T>({
          onChange(v);
          closeOptionsDropdown();
       },
-      [onChange, closeOptionsDropdown]
+      [onChange, closeOptionsDropdown],
    );
 
    const showDropDown = useMemo(() => isOpen && !disabled, [isOpen, disabled]);
 
    const displayValue = useMemo(
       () => formatValue?.(value) ?? value,
-      [formatValue, value]
+      [formatValue, value],
    );
 
    useEffect(() => {

--- a/app/routes/_site+/_components/_datepicker/date-picker/index.tsx
+++ b/app/routes/_site+/_components/_datepicker/date-picker/index.tsx
@@ -12,7 +12,19 @@ import {
 } from "./methods";
 import type { WeekStartDay } from "./types";
 
-export type DatePickerProps = {
+export interface DatePickerProps
+   extends PropsWithRef<
+      Omit<
+         HTMLProps<HTMLInputElement>,
+         | "onChange"
+         | "selected"
+         | "options"
+         | "value"
+         | "type"
+         | "name"
+         | "disabled"
+      >
+   > {
    /**
     * This function is called when the selected date is changed.
     */
@@ -39,18 +51,7 @@ export type DatePickerProps = {
     * If the DatePicker is disabled
     */
    disabled?: boolean;
-} & PropsWithRef<
-   Omit<
-      HTMLProps<HTMLInputElement>,
-      | "onChange"
-      | "selected"
-      | "options"
-      | "value"
-      | "type"
-      | "name"
-      | "disabled"
-   >
->;
+}
 
 /**
  * DatePicker component to pick dates
@@ -67,15 +68,15 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
          disabled = false,
          ...props
       },
-      ref
+      ref,
    ) => {
       const minDateValue = useMemo(
          () => minDate?.valueOf() ?? new Date(1900, 0, 1).valueOf(),
-         [minDate]
+         [minDate],
       );
       const maxDateValue = useMemo(
          () => maxDate?.valueOf() ?? dt.addYears(new Date(), 100).valueOf(),
-         [maxDate]
+         [maxDate],
       );
 
       // current month and year the user is viewing
@@ -83,12 +84,12 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
 
       const nextMonth = useCallback(
          () => setOpenedDate((d) => dt.addMonths(d, 1)),
-         [setOpenedDate]
+         [setOpenedDate],
       );
 
       const prevMonth = useCallback(
          () => setOpenedDate((d) => dt.addMonths(d, -1)),
-         [setOpenedDate]
+         [setOpenedDate],
       );
 
       const onMonthChange = useCallback(
@@ -98,18 +99,18 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
                   new Date(
                      d.getFullYear(),
                      getMonthNumberFromName(month),
-                     d.getDate()
-                  )
+                     d.getDate(),
+                  ),
             );
          },
-         [setOpenedDate]
+         [setOpenedDate],
       );
 
       const onYearChange = useCallback(
          (year: number) => {
             setOpenedDate((d) => new Date(year, d.getMonth(), d.getDate()));
          },
-         [setOpenedDate]
+         [setOpenedDate],
       );
 
       const handleClick = useCallback((d: Date) => onChange(d), [onChange]);
@@ -126,7 +127,7 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
                   {v}
                </p>
             )),
-         [weekStartsFrom, disabled]
+         [weekStartsFrom, disabled],
       );
 
       const daysOfMonthList = useMemo(
@@ -135,9 +136,9 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
                openedDate,
                minDateValue,
                maxDateValue,
-               weekStartsFrom
+               weekStartsFrom,
             ),
-         [openedDate, minDateValue, maxDateValue, weekStartsFrom]
+         [openedDate, minDateValue, maxDateValue, weekStartsFrom],
       );
 
       return (
@@ -175,7 +176,7 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
             </div>
          </div>
       );
-   }
+   },
 );
 
 DatePicker.displayName = "DatePicker";

--- a/app/routes/_site+/_components/_datepicker/date-picker/methods.ts
+++ b/app/routes/_site+/_components/_datepicker/date-picker/methods.ts
@@ -31,7 +31,7 @@ export const getMonthNameFromNumber = (month: number): string => {
    if (month < 0 || month > 11) {
       throw new Error(`Invalid month number: ${month}`);
    }
-   return MONTHS[month];
+   return MONTHS[month]!;
 };
 
 export const getMonthNumberFromName = (month: string): number => {
@@ -67,7 +67,7 @@ export const getMonthNumberFromName = (month: string): number => {
 
 export const getDayFromNumber = (
    day: number,
-   weekStartsFrom: WeekStartDay
+   weekStartsFrom: WeekStartDay,
 ): string => {
    if (day < 0 || day > 6) {
       throw new Error(`Invalid month number: ${day}`);
@@ -99,7 +99,7 @@ export const getDatesOfMonth = (
    date: Date,
    minDateValue: number,
    maxDateValue: number,
-   weekStartsFrom: WeekStartDay
+   weekStartsFrom: WeekStartDay,
 ): DisplayDate[] => {
    const currentYear = date.getFullYear();
    const currentMonth = date.getMonth();
@@ -165,7 +165,7 @@ export const getDatesOfMonth = (
       for (let i = 1; i < firstWeekDayOfMonth; i++) {
          const d = dt.addDays(
             previousMonthLastDay,
-            i - firstWeekDayOfMonth + 1
+            i - firstWeekDayOfMonth + 1,
          );
          dates.push({
             date: d,

--- a/app/routes/_site+/_components/_datepicker/date-picker/methods.ts
+++ b/app/routes/_site+/_components/_datepicker/date-picker/methods.ts
@@ -74,9 +74,9 @@ export const getDayFromNumber = (
    }
    switch (weekStartsFrom) {
       case "Monday":
-         return DAYS[(day + 1) % 7];
+         return DAYS[(day + 1) % 7]!;
       case "Sunday":
-         return DAYS[day];
+         return DAYS[day]!;
       default:
          throw new Error(`Invalid week start day: ${weekStartsFrom}`);
    }

--- a/app/routes/_site+/_components/_datepicker/time-picker/index.tsx
+++ b/app/routes/_site+/_components/_datepicker/time-picker/index.tsx
@@ -23,7 +23,13 @@ import CustomSelect from "../components/select";
 /**
  * Props for TimePicker React Component
  */
-export type TimePickerProps = {
+export interface TimePickerProps
+   extends PropsWithRef<
+      Omit<
+         HTMLProps<HTMLInputElement>,
+         "onChange" | "selected" | "options" | "value" | "disabled"
+      >
+   > {
    /**
     * This function is called when the selected date is changed.
     */
@@ -44,12 +50,7 @@ export type TimePickerProps = {
     * The number of minutes between each minute select option - default is 30
     */
    minutesInterval?: number;
-} & PropsWithRef<
-   Omit<
-      HTMLProps<HTMLInputElement>,
-      "onChange" | "selected" | "options" | "value" | "disabled"
-   >
->;
+}
 
 const meridiemOptions: OptionType<Meridiem>[] = [
    { value: Meridiem.AM, label: Meridiem.AM, disabled: false },

--- a/app/routes/_site+/_utils/getSiteSlug.server.ts
+++ b/app/routes/_site+/_utils/getSiteSlug.server.ts
@@ -15,7 +15,7 @@ export async function getSiteSlug(
    payload: Payload,
    user: RemixRequestContext["user"],
 ) {
-   let siteSlug = process.env.SITE_SLUG;
+   let siteSlug = process.env.SITE_SLUG ?? "hq";
 
    if (process.env.NODE_ENV == "development") return { siteSlug };
 
@@ -48,6 +48,7 @@ export async function getSiteSlug(
 
    let [subDomain] = hostname.split(".");
 
+   // Fixes the issue with fly.dev subdomains, make sure to define SITE_SLUG on fly secrets!
    if (subDomain && subDomain !== "localhost" && !hostname.includes("fly.dev"))
       siteSlug = subDomain;
 

--- a/app/routes/_site+/c_+/$collectionId_.$entryId/utils/_entryTypes.ts
+++ b/app/routes/_site+/c_+/$collectionId_.$entryId/utils/_entryTypes.ts
@@ -13,9 +13,9 @@ export type EntryType = {
    };
 };
 
-export type EntryAllData = EntryType & {
+export interface EntryAllData extends EntryType {
    embeddedContent: JSON;
-};
+}
 
 // https://stackoverflow.com/questions/40510611/typescript-interface-require-one-of-two-properties-to-exist
 type RequireOnlyOneOptional<T, Keys extends keyof T = keyof T> = Pick<

--- a/app/utils/third-parties/Script.tsx
+++ b/app/utils/third-parties/Script.tsx
@@ -56,13 +56,13 @@ const insertStylesheets = (stylesheets: string[]) => {
    // Stylesheets might have already been loaded if initialized with Script component
    // Re-inject styles here to handle scripts loaded via handleClientScriptLoad
    // ReactDOM.preinit handles dedup and ensures the styles are loaded only once
-   if (ReactDOM.preinit) {
-      stylesheets.forEach((stylesheet: string) => {
-         ReactDOM.preinit(stylesheet, { as: "style" });
-      });
+   // if (ReactDOM.preinit) {
+   //    stylesheets.forEach((stylesheet: string) => {
+   //       ReactDOM.preinit(stylesheet, { as: "style" });
+   //    });
 
-      return;
-   }
+   //    return;
+   // }
 
    // Case 2: Styles for afterInteractive/lazyOnload with pages injected via handleClientScriptLoad
    //
@@ -324,11 +324,11 @@ export function Script(props: ScriptProps): JSX.Element | null {
       // Case 2: Styles for beforeInteractive/worker with pages dir - Not handled yet
       // Case 3: Styles for afterInteractive/lazyOnload with appDir - handled here
       // Case 4: Styles for afterInteractive/lazyOnload with pages dir - handled in insertStylesheets function
-      if (stylesheets) {
-         stylesheets.forEach((styleSrc) => {
-            ReactDOM.preinit(styleSrc, { as: "style" });
-         });
-      }
+      // if (stylesheets) {
+      //    stylesheets.forEach((styleSrc) => {
+      //       ReactDOM.preinit(styleSrc, { as: "style" });
+      //    });
+      // }
 
       // Before interactive scripts need to be loaded by Next.js' runtime instead
       // of native <script> tags, because they no longer have `defer`.

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
       "custom-build:payload": "cross-env PAYLOAD_CONFIG_PATH=./app/db/payload.custom.config.ts payload build",
       "custom-build:server": "tsc -p tsconfig.custom.json",
       "start:custom": "cross-env PAYLOAD_CONFIG_PATH=dist/app/db/payload.custom.config.js NODE_ENV=production node dist/custom.server.js",
-      "typecheck": "tsc -p tsconfig.server.json",
+      "typecheck": "tsc -p tsconfig.json --diagnostics",
       "partytown": "partytown copylib public/~partytown",
       "generate:icons": "npx @sly-cli/sly add lucide-icons --overwrite --yes --directory ./public/icons",
       "generate:types": "cross-env PAYLOAD_CONFIG_PATH=./app/db/payload.config.ts yarn generate:types:clean",

--- a/scripts/resaveCollection.ts
+++ b/scripts/resaveCollection.ts
@@ -32,7 +32,7 @@ const resaveCollection = async () => {
 
    try {
       await Promise.all(
-         results.docs.map(async (result) => {
+         results.docs.map(async (result: any) => {
             const { id } = result;
             if (collectionSlug) {
                try {


### PR DESCRIPTION
See: 

https://github.com/getsentry/sentry/pull/30847

Instead of 

`type ButtonProps = React.HTMLAttributes<HTMLButtonElement> & { ... }`

do

`interface ButtonProps extends React.HTMLAttributes { ... }`

----

also fixed a bunch of type errors:

Found 84 errors in 16 files. -> Found 71 errors in 9 files.